### PR TITLE
Add support for creating streams that handle a subset of the total segments

### DIFF
--- a/lib/backup.js
+++ b/lib/backup.js
@@ -10,6 +10,8 @@ function Backup(options) {
   this.retries = options.retries || 10;
   this.delay = options.delay || 1000;
   this.concurrency = options.concurrency || 4;
+  this.startSegment = options.startSegment || 0;
+  this.totalSegments = options.totalSegments || this.concurrency;
 
   this.capacityInterval = null;
   this.itemsCount = 0;
@@ -58,8 +60,8 @@ Backup.prototype._readTable = function() {
     var limit = self.limit / self.concurrency | 0;
     limit = Math.max(limit, 1);
 
-    var segment = 0;
-    for (segment; segment < self.concurrency; segment++) {
+    var segment = self.startSegment;
+    for (segment; segment < self.startSegment + self.concurrency; segment++) {
       self._streamRecords(null, segment, limit, 0);
     }
   });
@@ -91,7 +93,7 @@ Backup.prototype._streamRecords = function(startKey, segment, limit, retries) {
     ReturnConsumedCapacity: 'TOTAL',
     ConsistentRead: true,
     Segment: segment,
-    TotalSegments: this.concurrency
+    TotalSegments: this.totalSegments
   };
 
   if (startKey) {


### PR DESCRIPTION
Hey I've found this project really useful, so thank you!

This is a small PR that adds support for creating multiple stream objects, each of which handles a subset of the total parallel scan.

I found this necessary to get over ~2K RCU consumed RCU on the box I was testing.  This allows for taking advantage of multiple CPU cores and/or parallelizing across multiple boxes.

It's currently undocumented, but if you think this is something that would be useful I'd be happy to add docs.  Thanks again!