### PR TITLE
Adding on demand flag for backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 *.json.gz
 .DS_Store
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The Backup constructor accepts an options object. The spec for that object:
  * `retries` - the number of retries for each read request. Default: 10.
  * `delay` - the target delay in milliseconds between each request. Default: 1000.
  * `concurrency` - the number of workers to use for reading the data. Each worker reads a Scan segment. Default: 4.
+ * `onDemand` - boolean to indicate [on demand](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand
+)
+ mode sets the capacity to [40.000](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#default-limits-throughput). Default false
 
 The actual capacity requirements are calculated on each request. One read unit equals to 4KB/s of throughput. DynamoDB Scan counts the total size of the items for the purpose of capacity usage which makes this operation very efficient. On each request, the used capacity is compared against the target capacity of the worker. The target capacity is then adjusted accordingly. The total target capacity is checked against DynamoDB every 60 seconds to see if auto-scaling has kicked in. The target capacity of the worker is calculated by dividing the total target capacity to the number of workers and rounding down to the nearest integer unit. The read capacity per worker can't be smaller than 1.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The Backup constructor accepts an options object. The spec for that object:
  * `retries` - the number of retries for each read request. Default: 10.
  * `delay` - the target delay in milliseconds between each request. Default: 1000.
  * `concurrency` - the number of workers to use for reading the data. Each worker reads a Scan segment. Default: 4.
- * `onDemand` - boolean to indicate [on demand](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand
-)
- mode sets the capacity to [40.000](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#default-limits-throughput). Default false
+ * `fixedCapacity` - Number to operate on a fixed capacity e.g. needed to utilize tables in [on demand mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand
+).
+ Make sure to consult the [available throughput in your region](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#default-limits-throughput). Default undefined
 
 The actual capacity requirements are calculated on each request. One read unit equals to 4KB/s of throughput. DynamoDB Scan counts the total size of the items for the purpose of capacity usage which makes this operation very efficient. On each request, the used capacity is compared against the target capacity of the worker. The target capacity is then adjusted accordingly. The total target capacity is checked against DynamoDB every 60 seconds to see if auto-scaling has kicked in. The target capacity of the worker is calculated by dividing the total target capacity to the number of workers and rounding down to the nearest integer unit. The read capacity per worker can't be smaller than 1.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The Restore constructor accepts an options object. The spec for that object:
  * `concurrency` - the number of workers to use for writing the data. Default: 1.
  * `bufferSize` - the size of the line buffer created by reading from readline. Default: 250 * `concurrency`.
  * `maxItems` - the maximum number of items in a batchWriteItem request. Default: 25. Max: 25.
+ * `fixedCapacity` - Number to operate on a fixed capacity e.g. needed to utilize tables in [on demand mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand
+).
+ Make sure to consult the [available throughput in your region](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#default-limits-throughput). Default undefined
 
 The same formulas for capacity sizing and request timings used for the Backup stream apply. There are certain differences though. One write unit equals to 1KB/s of throughput. DynamoDB BatchWriteItem counts the size of each individual item and the value is rounded up to the nearest KB. This makes the capacity sizing tad inefficient compared to Scan. The general limits for BatchWriteItem apply: up to 25 items per batch, 400KB as the maximum size of the item, and 16MB as the total size of the BatchWriteItem request.
 

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -5,7 +5,7 @@ var Readable = require('stream').Readable;
 
 function Backup(options) {
   this.ddb = options.client;
-  this.onDemand = options.onDemand || false;
+  this.fixedCapacity = parseInt(options.fixedCapacity);
   this.table = options.table;
   this.capacityPercentage = options.capacityPercentage || 25;
   this.retries = options.retries || 10;
@@ -41,8 +41,8 @@ Backup.prototype._end = function() {
 };
 
 Backup.prototype._setCapacity = function(units) {
-  if(this.onDemand){
-    units = 40000;
+  if(!Number.isNaN(this.fixedCapacity)){
+    units = this.fixedCapacity;
   }
   var readPercentage = (units * this.capacityPercentage / 100) | 0;
   this.limit = Math.max(readPercentage, 1);

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -5,6 +5,7 @@ var Readable = require('stream').Readable;
 
 function Backup(options) {
   this.ddb = options.client;
+  this.onDemand = options.onDemand || false;
   this.table = options.table;
   this.capacityPercentage = options.capacityPercentage || 25;
   this.retries = options.retries || 10;
@@ -40,6 +41,9 @@ Backup.prototype._end = function() {
 };
 
 Backup.prototype._setCapacity = function(units) {
+  if(this.onDemand){
+    units = 40000;
+  }
   var readPercentage = (units * this.capacityPercentage / 100) | 0;
   this.limit = Math.max(readPercentage, 1);
 };

--- a/lib/restore.js
+++ b/lib/restore.js
@@ -6,6 +6,7 @@ var PassThrough = require('stream').PassThrough;
 
 function Restore(options) {
   this.ddb = options.client;
+  this.fixedCapacity = parseInt(options.fixedCapacity);
   this.table = options.table;
   this.capacityPercentage = options.capacityPercentage || 25;
   this.retries = options.retries || 10;
@@ -67,6 +68,9 @@ Restore.prototype._readLines = function() {
 };
 
 Restore.prototype._setCapacity = function(units) {
+  if(!Number.isNaN(this.fixedCapacity)){
+    units = this.fixedCapacity;
+  }  
   var writePercentage = (units * this.capacityPercentage / 100) | 0;
   this.limit = Math.max(writePercentage, 1);
 };


### PR DESCRIPTION
if Dynamo DB in in on demand mode the backup runs extremely slow due to the fact, that dynamo reports the provisioned capacity to be 1. Available capacity in demand mode is 40k per table without a account limit. 
The remaining capacity is calculated by 40k*capacityPercentage if the flag onDemand is set to true.

Compare:

- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#default-limits-throughput

- https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/